### PR TITLE
fix some simple jsx typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ export function RedComponent() {
   return (
     <>
       {trans('minimumOrderPurchase', { amount: <strong style={{color: 'red'}}>12</strong> })}
-    </strong>
+    </>
   )
 }
 ```
@@ -331,12 +331,13 @@ import { transX } from "@mongez/react-localization";
 export function RedComponent() {
   return (
     <>
-      // will convert the jsx value to [object Object] if the converter is not set to jsxConverter in the configurations.
+      {/* will convert the jsx value to [object Object] if the converter is not set to jsxConverter in the configurations.*/}
+
       {trans('minimumOrderPurchase', { amount: <strong style={{color: 'red'}}>12</strong> })}
 
-      // works fine regardless configurations.
+      {/* works fine regardless configurations. */}
       {transX('minimumOrderPurchase', { amount: <strong style={{color: 'red'}}>12</strong> })}
-    </strong>
+    </>
   )
 }
 ```


### PR DESCRIPTION
I fixed simple typo in JSX examples (there was </strong> tag without opening tag) i replaced it with <></> _(Fragment tag)_ instead.